### PR TITLE
Reduce connection pool to 1 connection (fix for #5, #6)

### DIFF
--- a/config/hapi.js
+++ b/config/hapi.js
@@ -81,6 +81,7 @@ module.exports = function () {
         connections: {
           postgreDefault: {
             adapter: 'postgre',
+            poolSize: 1,
             host: Config.db.pg.host,
             port: Config.db.pg.port,
             database: Config.db.pg.database,


### PR DESCRIPTION
According to postgres adapter for sails https://github.com/balderdashy/sails-postgresql `pollSize` by default is `10` which is more then allowed by default configurations for postgres on lot of regular users laptops. Having just 1 connection is enough for hanx.js to work and that also fixes #5, #6 issues
